### PR TITLE
added option to allow page-access to certain users only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ return [
         'ignore' => [],
         'css' => false,
         'text' => 'This website is currently under maintenance and will be back online soon.',
+        'allowed-users' => []
     ]
 ];
 ```
@@ -50,6 +51,27 @@ You can also use one of the prefabricated blueprint parts:
 You could also add a `/.maintenance` file to the Kirby root directory to switch on maintenance mode. This method is used by [bnomei/kirby3-janitor](https://github.com/bnomei/kirby3-janitor) plugin. If you enter any text inside that file, this will be the output when the site is in maintenance mode.
 
 Suggested by https://github.com/moritzebeling/kirby-maintenance/issues/1
+
+## Allow page-access only to certain users
+
+With the `moritzebeling.kirby-maintenance.allowed-users`option you allow access only to certain users, e.g. for the development-team to check changes before allowing access to the content-team
+
+```php
+// site/config.php
+return [
+    // one line switch
+    'maintenance' => true,
+
+    // more detailed configuration
+    'moritzebeling.kirby-maintenance' => [
+      'allowed-users' => env('KIRBY_MAINTENANCE_ALLOWED_USERS') ? explode(',', env('KIRBY_MAINTENANCE_ALLOWED_USERS')) : []
+    ]
+```
+
+```dotenv
+# .env
+KIRBY_MAINTENANCE_ALLOWED_USERS=deployer1@develop.team,deployer2@develop.team
+```
 
 ## Add style
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "witoldwegner/kirby-maintenance",
+    "name": "moritzebeling/kirby-maintenance",
     "description": "Kirby Maintenance mode plugin",
-    "version": "1.0.2",
+    "version": "1.0.0",
     "type": "kirby-plugin",
     "homepage": "https://github.com/moritzebeling/kirby-maintenance",
     "time": "2023-01-22",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "moritzebeling/kirby-maintenance",
+    "name": "witoldwegner/kirby-maintenance",
     "description": "Kirby Maintenance mode plugin",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "type": "kirby-plugin",
     "homepage": "https://github.com/moritzebeling/kirby-maintenance",
     "time": "2023-01-22",

--- a/index.php
+++ b/index.php
@@ -55,7 +55,15 @@ class Maintenance {
     }
 
     public function showPageToLoggedinUser(){
-        return $this->kirby->user() ? true : false;
+        $user = $this->kirby->user();
+        if (!$user) {
+            return false;
+        }
+        $allowedUsers = $this->kirby->option('moritzebeling.kirby-maintenance.allowed-users', []);
+        if (count($allowedUsers) === 0) {
+            return true;
+        }
+        return in_array($user->email(), $allowedUsers);
     }
 
     public function setHeaders(){


### PR DESCRIPTION
I needed the possibility to allow page-access only to certain users.
E.g. when I'm deploying my changes I don't want the content-team of the customers to have access to the page until I checked everything's working
So I added option 
'moritzebeling.kirby-maintenance.allowed-users'